### PR TITLE
Remove 'Total Points Awarded' output from event stop command

### DIFF
--- a/src/commands/subcommands/stop.ts
+++ b/src/commands/subcommands/stop.ts
@@ -98,8 +98,7 @@ export async function execute(
   }
   
   embed.addFields(
-    { name: `Participants (${participantEntries.length})`, value: participantsText || "No participants" },
-    { name: "Total Points Awarded", value: `${totalPoints.toFixed(2)} points`, inline: true }
+    { name: `Participants (${participantEntries.length})`, value: participantsText || "No participants" }
   );
 
   await interaction.editReply({ embeds: [embed] });

--- a/src/commands/subcommands/stop.ts
+++ b/src/commands/subcommands/stop.ts
@@ -86,15 +86,12 @@ export async function execute(
   
   // Add participants to embed
   let participantsText = "";
-  let totalPoints = 0;
   
   for (const participant of participantEntries) {
     const hostTag = participant.isHost ? " 👑" : "";
     participantsText += `**${participant.name}**${hostTag}\n`;
     participantsText += `• Duration: ${participant.duration} minutes\n`;
     participantsText += `• Points: ${participant.points}\n\n`;
-    
-    totalPoints += parseFloat(participant.points);
   }
   
   embed.addFields(


### PR DESCRIPTION
Fixes #1: Removes the unintended 'Total Points Awarded' output from the event stop command.

This change removes the extra field in the event stop command's embed that was displaying the total points awarded, as mentioned in the issue description.