### PR TITLE
Remove 'Total Points Awarded' Output from Event Stop Command

### DIFF
--- a/src/commands/subcommands/stop.ts
+++ b/src/commands/subcommands/stop.ts
@@ -98,8 +98,7 @@ export async function execute(
   }
   
   embed.addFields(
-    { name: `Participants (${participantEntries.length})`, value: participantsText || "No participants" },
-    { name: "Total Points Awarded", value: `${totalPoints.toFixed(2)} points`, inline: true }
+    { name: `Participants (${participantEntries.length})`, value: participantsText || "No participants" }
   );
 
   await interaction.editReply({ embeds: [embed] });

--- a/src/commands/subcommands/stop.ts
+++ b/src/commands/subcommands/stop.ts
@@ -86,15 +86,12 @@ export async function execute(
   
   // Add participants to embed
   let participantsText = "";
-  let totalPoints = 0;
   
   for (const participant of participantEntries) {
     const hostTag = participant.isHost ? " 👑" : "";
     participantsText += `**${participant.name}**${hostTag}\n`;
     participantsText += `• Duration: ${participant.duration} minutes\n`;
     participantsText += `• Points: ${participant.points}\n\n`;
-    
-    totalPoints += parseFloat(participant.points);
   }
   
   embed.addFields(


### PR DESCRIPTION
## Description
Removes the unintended 'Total Points Awarded' output from the '/event stop' command as requested in Issue #1.

### Changes
- Removed `totalPoints` variable calculation
- Removed total points display in the event stop embed

### Motivation
The total points calculation was an unintended output that was not needed for the event stop functionality.

### Testing
- Verified that the event stop command works without displaying total points
- Ensured no functional changes to the existing event stop logic