### PR TITLE
Fix '/event me' duration display to clarify 'Participated' time

### DIFF
--- a/src/commands/subcommands/me.ts
+++ b/src/commands/subcommands/me.ts
@@ -49,7 +49,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
     for (const event of recentEvents) {
       const dateString = event.date.toLocaleDateString();
       const hostTag = event.wasHost ? " 👑" : "";
-      recentEventsText += `**${event.event_type}**${hostTag} - ${dateString} - ${event.points.toFixed(2)} points (${event.duration.toFixed(2)} min)\n`;
+      recentEventsText += `**${event.event_type}**${hostTag} - ${dateString} - ${event.points.toFixed(2)} points (Participated: ${event.duration.toFixed(2)} min)\n`;
     }
     
     embed.addFields({ 


### PR DESCRIPTION
Resolves Issue #4

Changes:
- Updated the duration display in '/event me' command to clarify that the time represents 'Participated' time
- Added the word 'Participated' before the duration to make the meaning clearer

This change addresses the issue where the 'min' in an event record was not clearly indicating the participated time.