### PR TITLE
Fix: Always display points in event records

### DIFF
--- a/src/commands/subcommands/records.ts
+++ b/src/commands/subcommands/records.ts
@@ -46,9 +46,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
         }
       }
       
-      const pointsText = record.points_earned !== undefined 
-        ? ` | Points: ${record.points_earned.toFixed(2)}` 
-        : '';
+      const pointsText = ` | Points: ${record.points_earned !== undefined ? record.points_earned.toFixed(2) : '0.00'}`;
       
       recordsText += `**${record.event_type}** - ${date}\n`;
       recordsText += `Participant: ${participantName}\n`;
@@ -57,9 +55,7 @@ export async function execute(interaction: ChatInputCommandInteraction): Promise
       console.error(`Failed to process record:`, error);
       
       const userId = record.user_id || record.creator_id || 'unknown';
-      const pointsText = record.points_earned !== undefined 
-        ? ` | Points: ${record.points_earned.toFixed(2)}` 
-        : '';
+      const pointsText = ` | Points: ${record.points_earned !== undefined ? record.points_earned.toFixed(2) : '0.00'}`;
       
       recordsText += `**${record.event_type}** - ${date}\n`;
       recordsText += `Participant: Unknown (${userId})\n`;


### PR DESCRIPTION
Resolves Issue #8

Changes:
- Modify event records display to always show points
- Default to '0.00' if points are not set
- Ensures consistent display of points in event records

This change ensures that the 'Points' column is always displayed after 'Duration', even if no points have been earned.